### PR TITLE
Issue 5630

### DIFF
--- a/src/include/duckdb/optimizer/join_order/join_order_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_order/join_order_optimizer.hpp
@@ -102,6 +102,7 @@ private:
 	void UpdateDPTree(JoinNode *new_plan);
 
 	void UpdateJoinNodesInFullPlan(JoinNode *node);
+	bool NodeInFullPlan(JoinNode *node);
 
 	std::pair<JoinRelationSet *, unique_ptr<LogicalOperator>>
 	GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted_relations, JoinNode *node);

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/pair.hpp"
-#include "duckdb/common/limits.hpp"
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/pair.hpp"
-#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/limits.hpp"
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
@@ -275,6 +275,11 @@ unique_ptr<JoinNode> JoinOrderOptimizer::CreateJoinTree(JoinRelationSet *set,
 	return result;
 }
 
+
+bool JoinOrderOptimizer::NodeInFullPlan(JoinNode *node) {
+	return join_nodes_in_full_plan.find(node->set->ToString()) != join_nodes_in_full_plan.end();
+}
+
 void JoinOrderOptimizer::UpdateJoinNodesInFullPlan(JoinNode *node) {
 	if (!node) {
 		return;
@@ -505,7 +510,7 @@ static vector<unordered_set<idx_t>> AddSuperSets(vector<unordered_set<idx_t>> cu
 }
 
 // works by first creating all sets with cardinality 1
-// then iterates over each previously create group of subsets and will only add a neighbor if the neighbor
+// then iterates over each previously created group of subsets and will only add a neighbor if the neighbor
 // is greater than all relations in the set.
 static vector<unordered_set<idx_t>> GetAllNeighborSets(JoinRelationSet *new_set, unordered_set<idx_t> &exclusion_set,
                                                        vector<idx_t> neighbors) {
@@ -541,6 +546,11 @@ static vector<unordered_set<idx_t>> GetAllNeighborSets(JoinRelationSet *new_set,
 }
 
 void JoinOrderOptimizer::UpdateDPTree(JoinNode *new_plan) {
+	if (!NodeInFullPlan(new_plan)) {
+		// if the new node is not in the full plan, feel free to return
+		// because you won't be updating the full plan.
+		return;
+	}
 	auto new_set = new_plan->set;
 	// now update every plan that uses this plan
 	unordered_set<idx_t> exclusion_set;
@@ -602,6 +612,7 @@ void JoinOrderOptimizer::SolveJoinOrderApproximately() {
 					// update the DP tree in case a plan created by the DP algorithm uses the node
 					// that was potentially just updated by EmitPair. You will get a use-after-free
 					// error if future plans rely on the old node that was just replaced.
+					// if node in FullPath, then updateDP tree.
 					UpdateDPTree(node);
 
 					if (!best_connection || node->GetCost() < best_connection->GetCost()) {

--- a/test/optimizer/issue_5630.test
+++ b/test/optimizer/issue_5630.test
@@ -2,6 +2,8 @@
 # description: Test Optimizer uses on multiple inner joins
 # group: [optimizer]
 
+# These test will take a noticeably long time if the optimizer tries to over optimize or
+# run unnecessary optimizations.
 
 statement ok
 CREATE TABLE MainTable (Id INT,
@@ -13,7 +15,14 @@ Value16_Id INT, Value17_Id INT, Value18_Id INT, Value19_Id INT, Value20_Id INT);
 statement ok
 CREATE or REPLACE TABLE ValueTable (Id INT, Value TEXT);
 
-mode skip
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id;
+
 
 statement ok
 SELECT * FROM MainTable T
@@ -22,6 +31,11 @@ INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
 INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
 INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
 INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
+INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
+INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
+INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
+INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id;
 
 statement ok
 SELECT * FROM MainTable T
@@ -35,6 +49,11 @@ INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
 INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
 INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
 INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
+INNER JOIN ValueTable T11 ON T.Value11_Id = T11.Id
+INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
+INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
+INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
+INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id;
 
 statement ok
 SELECT * FROM MainTable T
@@ -53,25 +72,9 @@ INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
 INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
 INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
 INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id
+INNER JOIN ValueTable T16 ON T.Value16_Id = T16.Id;
 
-statement ok
-SELECT * FROM MainTable T
-INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
-INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
-INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
-INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
-INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
-INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
-INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
-INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
-INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
-INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
-INNER JOIN ValueTable T11 ON T.Value11_Id = T11.Id
-INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
-INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
-INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
-INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id
-INNER JOIN ValueTable T16 ON T.Value16_Id = T16.Id
+mode unskip
 
 statement ok
 SELECT * FROM MainTable T
@@ -94,8 +97,4 @@ INNER JOIN ValueTable T16 ON T.Value16_Id = T16.Id
 INNER JOIN ValueTable T17 ON T.Value17_Id = T17.Id
 INNER JOIN ValueTable T18 ON T.Value18_Id = T18.Id
 INNER JOIN ValueTable T19 ON T.Value16_Id = T19.Id
-INNER JOIN ValueTable T20 ON T.Value20_Id = T20.Id
---540000ms
-
-
-mode unskip
+INNER JOIN ValueTable T20 ON T.Value20_Id = T20.Id;

--- a/test/optimizer/issue_5630.test
+++ b/test/optimizer/issue_5630.test
@@ -1,0 +1,101 @@
+# name: test/optimizer/issue_5630.test
+# description: Test Optimizer uses on multiple inner joins
+# group: [optimizer]
+
+
+statement ok
+CREATE TABLE MainTable (Id INT,
+Value1_Id INT, Value2_Id INT, Value3_Id INT, Value4_Id INT, Value5_Id INT,
+Value6_Id INT, Value7_Id INT, Value8_Id INT, Value9_Id INT, Value10_Id INT,
+Value11_Id INT, Value12_Id INT, Value13_Id INT, Value14_Id INT, Value15_Id INT,
+Value16_Id INT, Value17_Id INT, Value18_Id INT, Value19_Id INT, Value20_Id INT);
+
+statement ok
+CREATE or REPLACE TABLE ValueTable (Id INT, Value TEXT);
+
+mode skip
+
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
+INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
+INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
+INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
+INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
+
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
+INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
+INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
+INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
+INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
+INNER JOIN ValueTable T11 ON T.Value11_Id = T11.Id
+INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
+INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
+INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
+INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id
+
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
+INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
+INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
+INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
+INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
+INNER JOIN ValueTable T11 ON T.Value11_Id = T11.Id
+INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
+INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
+INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
+INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id
+INNER JOIN ValueTable T16 ON T.Value16_Id = T16.Id
+
+statement ok
+SELECT * FROM MainTable T
+INNER JOIN ValueTable T1 ON T.Value1_Id = T1.Id
+INNER JOIN ValueTable T2 ON T.Value2_Id = T2.Id
+INNER JOIN ValueTable T3 ON T.Value3_Id = T3.Id
+INNER JOIN ValueTable T4 ON T.Value4_Id = T4.Id
+INNER JOIN ValueTable T5 ON T.Value5_Id = T5.Id
+INNER JOIN ValueTable T6 ON T.Value6_Id = T6.Id
+INNER JOIN ValueTable T7 ON T.Value7_Id = T7.Id
+INNER JOIN ValueTable T8 ON T.Value8_Id = T8.Id
+INNER JOIN ValueTable T9 ON T.Value9_Id = T9.Id
+INNER JOIN ValueTable T10 ON T.Value10_Id = T10.Id
+INNER JOIN ValueTable T11 ON T.Value11_Id = T11.Id
+INNER JOIN ValueTable T12 ON T.Value12_Id = T12.Id
+INNER JOIN ValueTable T13 ON T.Value13_Id = T13.Id
+INNER JOIN ValueTable T14 ON T.Value14_Id = T14.Id
+INNER JOIN ValueTable T15 ON T.Value15_Id = T15.Id
+INNER JOIN ValueTable T16 ON T.Value16_Id = T16.Id
+INNER JOIN ValueTable T17 ON T.Value17_Id = T17.Id
+INNER JOIN ValueTable T18 ON T.Value18_Id = T18.Id
+INNER JOIN ValueTable T19 ON T.Value16_Id = T19.Id
+INNER JOIN ValueTable T20 ON T.Value20_Id = T20.Id
+--540000ms
+
+
+mode unskip


### PR DESCRIPTION
This fixes issue https://github.com/duckdb/duckdb/issues/5630 . The query would go to approximate join order solving, and we would unnecessarily update the DP tree. Now we only update the DP tree if the Emitted pair is actually in the created DP tree.