### PR TITLE
Default window functions to functions in system.main

### DIFF
--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -192,6 +192,10 @@ BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	unique_ptr<FunctionData> bind_info;
 	if (window.type == ExpressionType::WINDOW_AGGREGATE) {
 		//  Look up the aggregate function in the catalog
+		if (window.catalog == "" && window.schema == "") {
+			window.catalog = "system";
+			window.schema = "main";
+		}
 		auto func = Catalog::GetEntry<AggregateFunctionCatalogEntry>(context, window.catalog, window.schema,
 		                                                             window.function_name, false, error_context);
 		D_ASSERT(func->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -193,8 +193,8 @@ BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	if (window.type == ExpressionType::WINDOW_AGGREGATE) {
 		//  Look up the aggregate function in the catalog
 		if (window.catalog.empty() && window.schema.empty()) {
-			window.catalog = "system";
-			window.schema = "main";
+			window.catalog = SYSTEM_CATALOG;
+			window.schema = DEFAULT_SCHEMA;
 		}
 		auto func = Catalog::GetEntry<AggregateFunctionCatalogEntry>(context, window.catalog, window.schema,
 		                                                             window.function_name, false, error_context);

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -192,7 +192,7 @@ BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	unique_ptr<FunctionData> bind_info;
 	if (window.type == ExpressionType::WINDOW_AGGREGATE) {
 		//  Look up the aggregate function in the catalog
-		if (window.catalog == "" && window.schema == "") {
+		if (window.catalog.empty() && window.schema.empty()) {
 			window.catalog = "system";
 			window.schema = "main";
 		}

--- a/test/sql/window/test_window_with_matching_scalar_function.test
+++ b/test/sql/window/test_window_with_matching_scalar_function.test
@@ -9,10 +9,14 @@ statement ok
 CREATE TABLE t1 (a INT, b INT);
 
 statement ok
-INSERT INTO t1 VALUES (1, 1), (2, 1), (1, 2), (4, 2);
+CREATE MACRO "sum"(x) AS (CASE WHEN SUM(x) IS NULL THEN 0 ELSE SUM(x) END);
+
+query I
+SELECT sum(b) OVER () FROM t1;
+----
 
 statement ok
-CREATE MACRO "sum"(x) AS (CASE WHEN SUM(x) IS NULL THEN 0 ELSE SUM(x) END);
+INSERT INTO t1 VALUES (1, 1), (2, 1), (1, 2), (4, 2);
 
 query I
 SELECT sum(b) OVER () FROM t1;
@@ -22,3 +26,33 @@ SELECT sum(b) OVER () FROM t1;
 6
 6
 
+statement ok
+create schema schema2;
+
+statement ok
+create table schema2.table2 (a INT);
+
+statement ok
+INSERT INTO schema2.table2 values (1), (2);
+
+query I
+select sum(a) OVER () from schema2.table2;
+----
+3
+3
+
+statement ok
+ATTACH DATABASE ':memory:' AS db2;
+
+statement ok
+create table db2.table3 (a INT);
+
+statement ok
+INSERT INTO db2.table3 values (1), (2), (3);
+
+query I
+select sum(a) OVER () from db2.table3;
+----
+6
+6
+6

--- a/test/sql/window/test_window_with_matching_scalar_function.test
+++ b/test/sql/window/test_window_with_matching_scalar_function.test
@@ -1,5 +1,5 @@
 # name: test/sql/window/test_window_with_matching_scalar_function.test
-# description: When a scalar macro function with the same name as an aggregate function exists, make sure bind_window returns the aggregate funciton
+# description: When a scalar macro function with the same name as an aggregate function exists, make sure bind_window returns the aggregate function
 # group: [window]
 
 statement ok

--- a/test/sql/window/test_window_with_matching_scalar_function.test
+++ b/test/sql/window/test_window_with_matching_scalar_function.test
@@ -2,6 +2,8 @@
 # description: When a scalar macro function with the same name as an aggregate function exists, make sure bind_window returns the aggregate function
 # group: [window]
 
+require skip_reload
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/window/test_window_with_matching_scalar_function.test
+++ b/test/sql/window/test_window_with_matching_scalar_function.test
@@ -1,0 +1,24 @@
+# name: test/sql/window/test_window_with_matching_scalar_function.test
+# description: When a scalar macro function with the same name as an aggregate function exists, make sure bind_window returns the aggregate funciton
+# group: [window]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 (a INT, b INT);
+
+statement ok
+INSERT INTO t1 VALUES (1, 1), (2, 1), (1, 2), (4, 2);
+
+statement ok
+CREATE MACRO "sum"(x) AS (CASE WHEN SUM(x) IS NULL THEN 0 ELSE SUM(x) END);
+
+query I
+SELECT sum(b) OVER () FROM t1;
+----
+6
+6
+6
+6
+


### PR DESCRIPTION
Since users cannot create their own aggregate functions, we default any window function to have a catalog and schema of system and main.

Works when querying over tables in different schemas/catalogs