### PR TITLE
Default allow caps to false

### DIFF
--- a/src/include/duckdb/parser/keyword_helper.hpp
+++ b/src/include/duckdb/parser/keyword_helper.hpp
@@ -18,10 +18,10 @@ public:
 	static bool IsKeyword(const string &text);
 
 	//! Returns true if the given string needs to be quoted when written as an identifier
-	static bool RequiresQuotes(const string &text, bool allow_caps = false);
+	static bool RequiresQuotes(const string &text, bool allow_caps = true);
 
 	//! Writes a string that is optionally quoted + escaped so it can be used as an identifier
-	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = false);
+	static string WriteOptionallyQuoted(const string &text, char quote = '"', bool allow_caps = true);
 };
 
 } // namespace duckdb

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -592,7 +592,7 @@ test_that("rel_project does not automatically quote upper-case column names", {
   ref <- duckdb:::expr_reference(names(df))
   exprs <- list(ref)
   proj <- duckdb:::rel_project(rel, exprs)
-  ans <- duckdb:::rapi_rel_to_df(proj)
+  ans <- duckdb:::rapi_rel_to_altrep(proj)
   expect_equal(df, ans)
 })
 

--- a/tools/rpkg/tests/testthat/test_relational.R
+++ b/tools/rpkg/tests/testthat/test_relational.R
@@ -586,3 +586,13 @@ test_that("semi joins for eq_na_matches works", {
    expect_equal(res, data.frame(x=c(2, 2)))
 })
 
+test_that("rel_project does not automatically quote upper-case column names", {
+  df <- data.frame(B = 1)
+  rel <- duckdb:::rel_from_df(con, df)
+  ref <- duckdb:::expr_reference(names(df))
+  exprs <- list(ref)
+  proj <- duckdb:::rel_project(rel, exprs)
+  ans <- duckdb:::rapi_rel_to_df(proj)
+  expect_equal(df, ans)
+})
+


### PR DESCRIPTION
To fix https://github.com/duckdb/duckdb/issues/5900 we need to default the allow_caps to true for the functions `RequiresQuotes` and `WriteOptionallyQuoted`. Apparently a default value of false was needed to work around the Postgres parser lowercasing everything but that is no longer required.