### PR TITLE
set max queries to 2000

### DIFF
--- a/extension/sqlsmith/include/fuzzyduck.hpp
+++ b/extension/sqlsmith/include/fuzzyduck.hpp
@@ -21,7 +21,7 @@ public:
 
 	ClientContext &context;
 	uint32_t seed = 0;
-	idx_t max_queries = 0;
+	idx_t max_queries = 2000;
 	string complete_log;
 	string log;
 	bool verbose_output = false;


### PR DESCRIPTION
Throwing an error causes CI failures as shown here https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/6284137858/job/17065385676

If we revert https://github.com/duckdb/duckdb/pull/8945 to call the maximum amount of queries, then we can also run into recursive issues where calling FuzzFunctions calls FuzzFunctions again duckdb and we end up getting a timeout, which will also throw an error. 

Maybe it's better to have a depth count on fuzz all functions? But this seems like too much overhead for just a developer testing tool. Or we just exclude the function `duckfuzz` and `FuzzAllFunctions` from `FuzzAllFunctions`. These functions are called during the nightlies anyway and are only for developers, so if one does break, it's not a huge deal and will eventually get fixed