### PR TITLE
Squashed commit of the following:

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_extension_definitions()
 
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move"
+      "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move -Wimplicit-fallthrough"
   )
   if(CMAKE_COMPILER_IS_GNUCC)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -157,6 +157,10 @@ unique_ptr<BaseStatistics> DuckTableEntry::GetStatistics(ClientContext &context,
 	return storage->GetStatistics(context, column.StorageOid());
 }
 
+optional_ptr<BlockingSample> DuckTableEntry::GetSample() {
+	return storage->GetSample();
+}
+
 unique_ptr<CatalogEntry> DuckTableEntry::AlterEntry(ClientContext &context, AlterInfo &info) {
 	D_ASSERT(!internal);
 	if (info.type != AlterType::ALTER_TABLE) {

--- a/src/execution/operator/helper/physical_reservoir_sample.cpp
+++ b/src/execution/operator/helper/physical_reservoir_sample.cpp
@@ -82,7 +82,7 @@ SourceResultType PhysicalReservoirSample::GetData(ExecutionContext &context, Dat
 	if (!sink.sample) {
 		return SourceResultType::FINISHED;
 	}
-	auto sample_chunk = sink.sample->GetChunk();
+	auto sample_chunk = sink.sample->GetChunkAndShrink();
 	if (!sample_chunk) {
 		return SourceResultType::FINISHED;
 	}

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -17,6 +17,10 @@ string PragmaTableInfo(ClientContext &context, const FunctionParameters &paramet
 	return StringUtil::Format("SELECT * FROM pragma_table_info('%s');", parameters.values[0].ToString());
 }
 
+string PragmaTableSample(ClientContext &context, const FunctionParameters &parameters) {
+	return StringUtil::Format("SELECT * FROM pragma_table_sample('%s');", parameters.values[0].ToString());
+}
+
 string PragmaShowTables(ClientContext &context, const FunctionParameters &parameters) {
 	// clang-format off
 	return R"EOF(
@@ -211,6 +215,7 @@ string PragmaUserAgent(ClientContext &context, const FunctionParameters &paramet
 
 void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaCall("table_info", PragmaTableInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaCall("table_sample", PragmaTableSample, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaCall("metadata_info", PragmaMetadataInfo, {}));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_tables", PragmaShowTables));

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library_unity(
   pragma_metadata_info.cpp
   pragma_storage_info.cpp
   pragma_table_info.cpp
+  pragma_table_sample.cpp
   pragma_user_agent.cpp
   test_all_types.cpp
   test_vector_types.cpp)

--- a/src/function/table/system/pragma_table_sample.cpp
+++ b/src/function/table/system/pragma_table_sample.cpp
@@ -1,0 +1,91 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
+#include "duckdb/planner/expression/bound_parameter_expression.hpp"
+#include "duckdb/planner/binder.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+
+#include <algorithm>
+
+namespace duckdb {
+
+struct PragmaTableSampleFunctionData : public TableFunctionData {
+	explicit PragmaTableSampleFunctionData(CatalogEntry &entry_p) : entry(entry_p) {
+	}
+	CatalogEntry &entry;
+};
+
+struct PragmaTableSampleOperatorData : public GlobalTableFunctionState {
+	PragmaTableSampleOperatorData() : sample_offset(0) {
+	}
+	idx_t sample_offset;
+};
+
+static unique_ptr<FunctionData> PragmaTableSampleBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+
+	// look up the table name in the catalog
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+
+	auto &entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog, qname.schema, qname.name);
+	if (entry.type != CatalogType::TABLE_ENTRY) {
+		throw NotImplementedException("Invalid Catalog type passed to table_sample()");
+	}
+	auto &table_entry = entry.Cast<TableCatalogEntry>();
+	auto types = table_entry.GetTypes();
+	for (auto &type : types) {
+		return_types.push_back(type);
+	}
+	for (idx_t i = 0; i < types.size(); i++) {
+		auto log_index = LogicalIndex(i);
+		auto &col = table_entry.GetColumn(log_index);
+		names.push_back(col.GetName());
+	}
+
+	return make_uniq<PragmaTableSampleFunctionData>(entry);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaTableSampleInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<PragmaTableSampleOperatorData>();
+}
+
+static void PragmaTableSampleTable(ClientContext &context, PragmaTableSampleOperatorData &data,
+                                   TableCatalogEntry &table, DataChunk &output) {
+	// if table has statistics.
+	// copy the sample of statistics into the output chunk
+	auto sample = table.GetSample();
+	if (sample) {
+		auto sample_chunk = sample->GetChunk(data.sample_offset);
+		if (sample_chunk) {
+			sample_chunk->Copy(output, 0);
+			data.sample_offset += sample_chunk->size();
+		}
+	}
+}
+
+static void PragmaTableSampleFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<PragmaTableSampleFunctionData>();
+	auto &state = data_p.global_state->Cast<PragmaTableSampleOperatorData>();
+	switch (bind_data.entry.type) {
+	case CatalogType::TABLE_ENTRY:
+		PragmaTableSampleTable(context, state, bind_data.entry.Cast<TableCatalogEntry>(), output);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented catalog type for pragma_table_sample");
+	}
+}
+
+void PragmaTableSample::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_table_sample", {LogicalType::VARCHAR}, PragmaTableSampleFunction,
+	                              PragmaTableSampleBind, PragmaTableSampleInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -13,6 +13,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaPlatform::RegisterFunction(*this);
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
+	PragmaTableSample::RegisterFunction(*this);
 	PragmaStorageInfo::RegisterFunction(*this);
 	PragmaMetadataInfo::RegisterFunction(*this);
 	PragmaDatabaseSize::RegisterFunction(*this);

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -30,6 +30,8 @@ public:
 	//! Get statistics of a column (physical or virtual) within the table
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
 
+	optional_ptr<BlockingSample> GetSample() override;
+
 	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 
 	void SetAsRoot() override;

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/parser/column_list.hpp"
 #include "duckdb/parser/constraint.hpp"
 #include "duckdb/planner/bound_constraint.hpp"
+#include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/catalog/catalog_entry/table_column_type.hpp"
@@ -82,6 +83,8 @@ public:
 
 	//! Get statistics of a column (physical or virtual) within the table
 	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) = 0;
+
+	virtual optional_ptr<BlockingSample> GetSample() = 0;
 
 	//! Returns the column index of the specified column name.
 	//! If the column does not exist:

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -6,6 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+// whats the issue with sotring percentage samples in local state?
+// mostly with merging
+// if you have multiple unfinished samples during merging, then each unfinished sample needs to be merged
+// The problem is if you have two samples that have seen below the reservoir threashold, but they have
+// weights etc.
+// I.e
+// Sample 1 has 40,000 tuples after seeing 68640 rows.
+// Sample 2 has 40,000 tuples after seeing 85600 rows.
+//
+// Desired result after merging is
+// Sample (1+2) has 40,000 tuples after seeing 100,000 rows
+// Sample 3 has 8640 tuples after seeing 54,240 rows
+//           - all samples in sample 3 have the weights from when they were in sample 2.
+
 #pragma once
 
 #include "duckdb/common/common.hpp"
@@ -56,7 +70,8 @@ public:
 	virtual void Finalize() = 0;
 	//! Fetches a chunk from the sample. Note that this method is destructive and should only be used after the
 	//! sample is completely built.
-	virtual unique_ptr<DataChunk> GetChunk() = 0;
+	virtual unique_ptr<DataChunk> GetChunkAndShrink() = 0;
+	virtual unique_ptr<DataChunk> GetChunk(idx_t offset = 0) = 0;
 	BaseReservoirSampling base_reservoir_sample;
 
 protected:
@@ -74,7 +89,8 @@ public:
 
 	//! Fetches a chunk from the sample. Note that this method is destructive and should only be used after the
 	//! sample is completely built.
-	unique_ptr<DataChunk> GetChunk() override;
+	unique_ptr<DataChunk> GetChunkAndShrink() override;
+	unique_ptr<DataChunk> GetChunk(idx_t offset = 0) override;
 	void Finalize() override;
 
 private:
@@ -86,7 +102,7 @@ private:
 
 public:
 	Allocator &allocator;
-	//! cardinality of the current resevoir sample
+	//! cardinality of the current resevior sample
 	idx_t num_added_samples;
 	//! The size of the reservoir sample.
 	//! when calculating percentages, it is set to reservoir_threshold * percentage
@@ -109,7 +125,8 @@ public:
 
 	//! Fetches a chunk from the sample. Note that this method is destructive and should only be used after the
 	//! sample is completely built.
-	unique_ptr<DataChunk> GetChunk() override;
+	unique_ptr<DataChunk> GetChunkAndShrink() override;
+	unique_ptr<DataChunk> GetChunk(idx_t offset = 0) override;
 	void Finalize() override;
 
 private:
@@ -126,7 +143,8 @@ private:
 	vector<unique_ptr<ReservoirSample>> finished_samples;
 	//! The amount of tuples that have been processed so far (not put in the reservoir, just processed)
 	idx_t current_count = 0;
-	//! Whether or not the stream is finalized. The stream is automatically finalized on the first call to GetChunk();
+	//! Whether or not the stream is finalized. The stream is automatically finalized on the first call to
+	//! GetChunkAndShrink();
 	bool is_finalized;
 };
 

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -21,6 +21,10 @@ struct PragmaTableInfo {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaTableSample {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct PragmaStorageInfo {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -165,6 +165,9 @@ public:
 
 	//! Get statistics of a physical column within the table
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id);
+
+	//! Get table sample
+	optional_ptr<BlockingSample> GetSample();
 	//! Sets statistics of a physical column within the table
 	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
 
@@ -216,6 +219,8 @@ private:
 	mutex append_lock;
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
+	//! Sample of the table collected during ingestion
+	unique_ptr<BlockingSample> sample;
 	//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
 	//! that can be appended to
 	atomic<bool> is_root;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -108,6 +108,7 @@ public:
 
 	void CopyStats(TableStatistics &stats);
 	unique_ptr<BaseStatistics> CopyStats(column_t column_id);
+	optional_ptr<BlockingSample> GetSample();
 	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
 
 	AttachedDatabase &GetAttached();

--- a/src/include/duckdb/storage/table/table_statistics.hpp
+++ b/src/include/duckdb/storage/table/table_statistics.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/execution/reservoir_sample.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/storage/statistics/column_statistics.hpp"
 
@@ -51,6 +52,9 @@ public:
 
 	void Serialize(Serializer &serializer) const;
 	void Deserialize(Deserializer &deserializer, ColumnList &columns);
+
+	//! Sample for table
+	unique_ptr<BlockingSample> sample;
 
 private:
 	//! The statistics lock

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -53,6 +53,9 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 		this->row_groups->InitializeEmpty();
 		D_ASSERT(row_groups->GetTotalRows() == 0);
 	}
+	if (data && data->table_stats.sample) {
+		this->sample = std::move(data->table_stats.sample);
+	}
 	row_groups->Verify();
 }
 
@@ -1218,6 +1221,10 @@ unique_ptr<BaseStatistics> DataTable::GetStatistics(ClientContext &context, colu
 void DataTable::SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats) {
 	D_ASSERT(column_id != COLUMN_IDENTIFIER_ROW_ID);
 	row_groups->SetDistinct(column_id, std::move(distinct_stats));
+}
+
+optional_ptr<BlockingSample> DataTable::GetSample() {
+	return row_groups->GetSample();
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/storage/table/persistent_table_data.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/execution/reservoir_sample.hpp"
 
 namespace duckdb {
 
@@ -9,6 +10,9 @@ void TableStatistics::Initialize(const vector<LogicalType> &types, PersistentTab
 	D_ASSERT(Empty());
 
 	column_stats = std::move(data.table_stats.column_stats);
+	auto &allocator = Allocator::DefaultAllocator();
+	idx_t sample_size = STANDARD_VECTOR_SIZE;
+	sample = make_uniq<ReservoirSample>(allocator, sample_size, -1);
 	if (column_stats.size() != types.size()) { // LCOV_EXCL_START
 		throw IOException("Table statistics column count is not aligned with table column count. Corrupt file?");
 	} // LCOV_EXCL_STOP
@@ -17,6 +21,8 @@ void TableStatistics::Initialize(const vector<LogicalType> &types, PersistentTab
 void TableStatistics::InitializeEmpty(const vector<LogicalType> &types) {
 	D_ASSERT(Empty());
 
+	auto &allocator = Allocator::DefaultAllocator();
+	sample = make_uniq<ReservoirSample>(allocator, STANDARD_VECTOR_SIZE, -1);
 	for (auto &type : types) {
 		column_stats.push_back(ColumnStatistics::CreateEmptyStats(type));
 	}
@@ -26,6 +32,7 @@ void TableStatistics::InitializeAddColumn(TableStatistics &parent, const Logical
 	D_ASSERT(Empty());
 
 	lock_guard<mutex> stats_lock(parent.stats_lock);
+	sample = nullptr;
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		column_stats.push_back(parent.column_stats[i]);
 	}
@@ -36,6 +43,7 @@ void TableStatistics::InitializeRemoveColumn(TableStatistics &parent, idx_t remo
 	D_ASSERT(Empty());
 
 	lock_guard<mutex> stats_lock(parent.stats_lock);
+	sample = nullptr;
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		if (i != removed_column) {
 			column_stats.push_back(parent.column_stats[i]);
@@ -68,6 +76,14 @@ void TableStatistics::InitializeAddConstraint(TableStatistics &parent) {
 void TableStatistics::MergeStats(TableStatistics &other) {
 	auto l = GetLock();
 	D_ASSERT(column_stats.size() == other.column_stats.size());
+	// if the sample has been nullified, no need to merge.
+	if (sample) {
+		auto chunk = other.sample->GetChunkAndShrink();
+		while (chunk) {
+			sample->AddToReservoir(*chunk);
+			chunk = other.sample->GetChunkAndShrink();
+		}
+	}
 	for (idx_t i = 0; i < column_stats.size(); i++) {
 		if (column_stats[i]) {
 			D_ASSERT(other.column_stats[i]);

--- a/test/sql/sample/table_sample.test
+++ b/test/sql/sample/table_sample.test
@@ -14,15 +14,6 @@ select * from pragma_table_sample('integers');
 ----
 2048
 
-mode output_result
 
 statement ok
 select * from pragma_table_sample('integers');
-
-
-mode skip
-
-query I
-select count(*) from integers USING SAMPLE 99.0% (Reservoir);
-----
-990000

--- a/test/sql/sample/table_sample.test
+++ b/test/sql/sample/table_sample.test
@@ -1,18 +1,18 @@
-# name: test/sql/sample/large_reservoir_sample.test_slow
+# name: test/sql/sample/table_sample.test_slow
 # description: Test reservoir sample crash on large data sets
 # group: [sample]
 
-#statement ok
-#PRAGMA enable_verification;
+statement ok
+PRAGMA enable_verification;
 
 
 statement ok
 create table integers as (select (range + 5)::VARCHAR a, range b from range(10000));
 
-#query I
-#select * from pragma_table_sample('integers');
-#----
-#2048
+query I
+select * from pragma_table_sample('integers');
+----
+2048
 
 mode output_result
 


### PR DESCRIPTION
Cleaned up PR for adding table samples to table statistics etc. 
Things that still need to be done. This PR will really jus tbe adding the basic table sample functionality and not much else. The table samples won't even be used anywhere, and they will be discarded as soon as a table is updated.

- [ ]  Serialize and deserialize the table sample
- [ ] Add more test cases were the table gets updated and we test if the sample is still valid
    - Test joins between table samples
- [ ] make sure that the same sample can be collected if the seed is set properly every time. 


Ideas for the future?
- maybe the size of the sample can be determined by the user? Then we can test what sample sizes have the best effect on creating good join orders.
- allow the table sample to be updated whenever the user asks. 
- update the sample when the table is updates for all possible updates