### PR TITLE
remove code to nuke cache

### DIFF
--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -216,6 +216,4 @@ else:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}")
 
-# nuke cached benchmark data between runs
-shutil.rmtree('duckdb_benchmark_data')
 exit(exit_code)

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -216,4 +216,7 @@ else:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}")
 
+# nuke cached benchmark data between runs
+if os.path.isdir("duckdb_benchmark_data"):
+    shutil.rmtree('duckdb_benchmark_data')
 exit(exit_code)


### PR DESCRIPTION
Caused the incorrect false positive of https://github.com/duckdblabs/duckdb-internal/actions/runs/8034596519

I don't understand why we nuke cache after running the benchmark runner. 

1. We only nuke cache in the current directory. Why don't we then also nuke it for the old duckdb binary / old duckdb_benchmark_data?
2. The regression test runner runs each query 5 times, eventually cache plays a part in the latter runs. So why nuke it after a regression_test_run?
3. If someone runs the regression_test_runner locally, they will end up removing some of their own data. 
