### PR TITLE
check for out of order ness

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -552,7 +552,7 @@ public:
 		}
 		bool require_extra_columns =
 		    result->multi_file_reader_state && result->multi_file_reader_state->RequiresExtraColumns();
-		if (input.CanRemoveFilterColumns() || require_extra_columns) {
+		if (input.CanRemoveFilterColumns() || require_extra_columns || input.ColumnsOutOfOrder()) {
 			if (!input.projection_ids.empty()) {
 				result->projection_ids = input.projection_ids;
 			} else {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -156,6 +156,17 @@ struct TableFunctionInitInput {
 		// Fewer columns need to be projected out than that we scan.
 		return true;
 	}
+
+	bool ColumnsOutOfOrder() const {
+		if (projection_ids.size() == column_indexes.size()) {
+			for (idx_t i = 0; i < projection_ids.size(); i++) {
+				if (projection_ids[i] != i) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 };
 
 struct TableFunctionInput {


### PR DESCRIPTION
When creating the GlobalTableFunctionState for a multi file function, some extensions can reject filter pushdowns when `supports_pushdown_type` is called. This rejection appends the column to the projection_ids. In some cases projection_ids and column_ids will then be the exact same, but the columns will be out of order due to the rejection. Without honoring projection_ids in that case, output_chunk types follow projection_id ordering but the executor processes all// reader_data.expressions in column_ids order, causing type mismatches. DuckDB-Iceberg currently does this by rejecting filters on equality delete columns