### PR TITLE
GetDefaultSchema should retrun optional<Identifier>

### DIFF
--- a/.github/config/extensions/fts.cmake
+++ b/.github/config/extensions/fts.cmake
@@ -4,4 +4,5 @@ duckdb_extension_load(fts
         GIT_URL https://github.com/duckdb/duckdb-fts
         GIT_TAG 2266e67d01c737cb65114e77c7c672e58869a635
         TEST_DIR test/sql
+        APPLY_PATCHES
 )

--- a/.github/patches/extensions/ducklake/0009-get-default-schema-optional.patch
+++ b/.github/patches/extensions/ducklake/0009-get-default-schema-optional.patch
@@ -1,0 +1,19 @@
+diff --git a/src/storage/ducklake_transaction.cpp b/src/storage/ducklake_transaction.cpp
+index 0dacb7d2..9ff5b3b3 100644
+--- a/src/storage/ducklake_transaction.cpp
++++ b/src/storage/ducklake_transaction.cpp
+@@ -1607,7 +1607,13 @@ Identifier DuckLakeTransaction::GetDefaultSchemaName() {
+ 	auto &metadata_context = *connection->context;
+ 	auto &db_manager = DatabaseManager::Get(metadata_context);
+ 	auto metadb = db_manager.GetDatabase(metadata_context, Identifier(ducklake_catalog.MetadataDatabaseName()));
+-	return metadb->GetCatalog().GetDefaultSchema();
++	auto default_schema = metadb->GetCatalog().GetDefaultSchema();
++	if (!default_schema) {
++		throw InvalidInputException("DuckLake metadata catalog \"%s\" has no default schema - set METADATA_SCHEMA "
++		                            "explicitly in ATTACH",
++		                            ducklake_catalog.MetadataDatabaseName());
++	}
++	return *default_schema;
+ }
+ 
+ DuckLakeSnapshot DuckLakeTransaction::GetSnapshot() {

--- a/.github/patches/extensions/fts/0001-get-default-schema-optional.patch
+++ b/.github/patches/extensions/fts/0001-get-default-schema-optional.patch
@@ -1,0 +1,22 @@
+diff --git a/src/fts_indexing.cpp b/src/fts_indexing.cpp
+index 581646b..c9305fd 100644
+--- a/src/fts_indexing.cpp
++++ b/src/fts_indexing.cpp
+@@ -27,9 +27,15 @@ static QualifiedName GetQualifiedName(ClientContext &context,
+     if (!qname.Catalog().empty()) {
+       schema_path.push_back(qname.Catalog());
+     }
+-    schema_path.push_back(
++    auto default_schema =
+         ClientData::Get(context).catalog_search_path->GetDefaultSchema(
+-            context, qname.Catalog()));
++            context, qname.Catalog());
++    if (!default_schema) {
++      throw CatalogException("cannot resolve '%s' - catalog '%s' has no "
++                             "default schema, qualify the name with a schema",
++                             qname_str, qname.Catalog().GetIdentifierName());
++    }
++    schema_path.push_back(*default_schema);
+     qname = qname.WithQualification(std::move(schema_path));
+   }
+   return qname;

--- a/.github/patches/extensions/iceberg/0008-get-default-schema-optional.patch
+++ b/.github/patches/extensions/iceberg/0008-get-default-schema-optional.patch
@@ -1,0 +1,35 @@
+diff --git a/src/common/iceberg_utils.cpp b/src/common/iceberg_utils.cpp
+index a80c0d44..fb88e016 100644
+--- a/src/common/iceberg_utils.cpp
++++ b/src/common/iceberg_utils.cpp
+@@ -150,7 +150,12 @@ optional_ptr<CatalogEntry> IcebergUtils::GetTableEntry(ClientContext &context, s
+ 	}
+ 	case 1: {
+ 		auto schema = catalog.GetDefaultSchema();
+-		auto table_entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, schema,
++		if (!schema) {
++			throw InvalidInputException(
++			    "Cannot resolve table name %s - catalog %s has no default schema, qualify the name with a schema",
++			    input_string, catalog.GetName());
++		}
++		auto table_entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, *schema,
+ 		                                    Identifier(qualified_name[0]), OnEntryNotFound::THROW_EXCEPTION);
+ 		return table_entry;
+ 	}
+diff --git a/src/include/catalog/rest/iceberg_catalog.hpp b/src/include/catalog/rest/iceberg_catalog.hpp
+index 6e1ab95e..3c6d9a4a 100644
+--- a/src/include/catalog/rest/iceberg_catalog.hpp
++++ b/src/include/catalog/rest/iceberg_catalog.hpp
+@@ -120,7 +120,11 @@ public:
+ 	bool CheckAmbiguousCatalogOrSchema(ClientContext &context, const Identifier &schema) override {
+ 		return false;
+ 	}
+-	Identifier GetDefaultSchema() const override {
++	optional<Identifier> GetDefaultSchema() const override {
++		if (default_schema.empty()) {
++			//! no default schema was configured - do not fall back to one
++			return nullopt;
++		}
+ 		return default_schema;
+ 	}
+ 	ErrorData SupportsCreateTable(BoundCreateTableInfo &info) override;

--- a/.github/patches/extensions/postgres_scanner/0005-get-default-schema-optional.patch
+++ b/.github/patches/extensions/postgres_scanner/0005-get-default-schema-optional.patch
@@ -1,0 +1,15 @@
+diff --git a/src/include/storage/postgres_catalog.hpp b/src/include/storage/postgres_catalog.hpp
+index 6e1e348..ab520cd 100644
+--- a/src/include/storage/postgres_catalog.hpp
++++ b/src/include/storage/postgres_catalog.hpp
+@@ -47,8 +47,8 @@ public:
+ 	string GetCatalogType() override {
+ 		return "postgres";
+ 	}
+-	Identifier GetDefaultSchema() const override {
+-		return default_schema.empty() ? "public" : default_schema;
++	optional<Identifier> GetDefaultSchema() const override {
++		return default_schema.empty() ? Identifier("public") : default_schema;
+ 	}
+ 
+ 	string GetConnectionString();

--- a/.github/patches/extensions/unity_catalog/0004-get-default-schema-optional.patch
+++ b/.github/patches/extensions/unity_catalog/0004-get-default-schema-optional.patch
@@ -1,0 +1,30 @@
+diff --git a/src/include/storage/unity_catalog.hpp b/src/include/storage/unity_catalog.hpp
+index cd000ae..bf8d275 100644
+--- a/src/include/storage/unity_catalog.hpp
++++ b/src/include/storage/unity_catalog.hpp
+@@ -81,7 +81,7 @@ public:
+ 	                                            unique_ptr<LogicalOperator> plan) override;
+ 
+ 	DatabaseSize GetDatabaseSize(ClientContext &context) override;
+-	Identifier GetDefaultSchema() const override;
++	optional<Identifier> GetDefaultSchema() const override;
+ 	void OnDetach(ClientContext &context) override;
+ 
+ 	//! Whether or not this is an in-memory UC database
+diff --git a/src/storage/unity_catalog.cpp b/src/storage/unity_catalog.cpp
+index 53f44ee..48c093e 100644
+--- a/src/storage/unity_catalog.cpp
++++ b/src/storage/unity_catalog.cpp
+@@ -73,7 +73,11 @@ string UnityCatalog::GetDBPath() {
+ 	return internal_name;
+ }
+ 
+-Identifier UnityCatalog::GetDefaultSchema() const {
++optional<Identifier> UnityCatalog::GetDefaultSchema() const {
++	if (default_schema.empty()) {
++		//! auto-detection failed and no DEFAULT_SCHEMA was configured on ATTACH
++		return nullopt;
++	}
+ 	return default_schema;
+ }
+ 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -599,10 +599,14 @@ vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, c
 		}
 		if (entries.empty()) {
 			auto catalog_entry = Catalog::GetCatalogEntry(context, catalog);
-			if (catalog_entry) {
-				entries.emplace_back(catalog, catalog_entry->GetDefaultSchema());
-			} else {
+			if (!catalog_entry) {
 				entries.emplace_back(catalog, DEFAULT_SCHEMA);
+			} else {
+				auto default_schema = catalog_entry->GetDefaultSchema();
+				// a catalog without a default schema has no implicit schema to fall back on
+				if (default_schema) {
+					entries.emplace_back(catalog, *default_schema);
+				}
 			}
 		}
 	} else {
@@ -1194,10 +1198,13 @@ CatalogEntryLookup Catalog::TryLookupDefaultSchema(CatalogEntryRetriever &retrie
 		if (!catalog_entry) {
 			continue;
 		}
+		auto default_schema = catalog_entry->GetDefaultSchema();
+		if (!default_schema) {
+			continue;
+		}
 		auto transaction = catalog_entry->GetCatalogTransaction(retriever.GetContext());
-		EntryLookupInfo default_schema_lookup(lookup_info,
-		                                      QualifiedName(catalog_entry->GetName(), catalog_entry->GetDefaultSchema(),
-		                                                    lookup_info.GetEntryIdentifier()));
+		EntryLookupInfo default_schema_lookup(
+		    lookup_info, QualifiedName(catalog_entry->GetName(), *default_schema, lookup_info.GetEntryIdentifier()));
 		auto result = catalog_entry->TryLookupEntryInternal(transaction, default_schema_lookup);
 		if (result.Found() || result.error.HasError()) {
 			return result;
@@ -1479,8 +1486,8 @@ ErrorData Catalog::SupportsCreateTable(BoundCreateTableInfo &info) {
 	return ErrorData();
 }
 
-Identifier Catalog::GetDefaultSchema() const {
-	return DEFAULT_SCHEMA;
+optional<Identifier> Catalog::GetDefaultSchema() const {
+	return Identifier(DEFAULT_SCHEMA);
 }
 
 //! Whether this catalog has a default table. Catalogs with a default table can be queries by their catalog name

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -182,11 +182,14 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPath
 		if (path.GetCatalog().empty()) {
 			auto catalog = Catalog::GetCatalogEntry(context, path.GetSchema());
 			if (catalog) {
-				auto schema = catalog->GetSchema(context, catalog->GetDefaultSchema(), OnEntryNotFound::RETURN_NULL);
-				if (schema) {
-					path.SetCatalog(path.GetSchema());
-					path.SetSchema(schema->name);
-					continue;
+				auto default_schema = catalog->GetDefaultSchema();
+				if (default_schema) {
+					auto schema = catalog->GetSchema(context, *default_schema, OnEntryNotFound::RETURN_NULL);
+					if (schema) {
+						path.SetCatalog(path.GetSchema());
+						path.SetSchema(schema->name);
+						continue;
+					}
 				}
 			}
 		}
@@ -238,7 +241,7 @@ Identifier CatalogSearchPath::GetDefaultSchema(const Identifier &catalog) const 
 	return DEFAULT_SCHEMA;
 }
 
-Identifier CatalogSearchPath::GetDefaultSchema(ClientContext &context, const Identifier &catalog) const {
+optional<Identifier> CatalogSearchPath::GetDefaultSchema(ClientContext &context, const Identifier &catalog) const {
 	for (auto &path : paths) {
 		if (path.GetCatalog() == TEMP_CATALOG) {
 			continue;
@@ -251,7 +254,7 @@ Identifier CatalogSearchPath::GetDefaultSchema(ClientContext &context, const Ide
 	if (catalog_entry) {
 		return catalog_entry->GetDefaultSchema();
 	}
-	return DEFAULT_SCHEMA;
+	return Identifier(DEFAULT_SCHEMA);
 }
 
 Identifier CatalogSearchPath::GetDefaultCatalog(const Identifier &schema) const {
@@ -316,7 +319,11 @@ vector<CatalogSearchEntry> CatalogSearchPath::GetWithPrecedenceSchemas(ClientCon
 			if (!catalog_entry) {
 				continue;
 			}
-			res.emplace_back(path.GetCatalog(), catalog_entry->GetDefaultSchema());
+			auto default_schema = catalog_entry->GetDefaultSchema();
+			if (!default_schema) {
+				continue;
+			}
+			res.emplace_back(path.GetCatalog(), *default_schema);
 		} else {
 			res.emplace_back(path);
 		}

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/exception/catalog_exception.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/parser/query_error_context.hpp"
@@ -416,8 +417,10 @@ public:
 		return CatalogLookupBehavior::STANDARD;
 	}
 
-	//! Returns the default schema of the catalog
-	virtual Identifier GetDefaultSchema() const;
+	//! Returns the default schema of the catalog, or nullopt if the catalog has no default schema.
+	//! Catalogs without a default schema are never probed with an implicit schema for unqualified lookups.
+	//! A returned value is always non-empty - an empty Identifier means "unspecified" elsewhere in the catalog.
+	virtual optional<Identifier> GetDefaultSchema() const;
 
 	//! The default table is used for `SELECT * FROM <catalog_name>;`
 	//! FIXME: these should be virtual methods

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -10,6 +10,7 @@
 
 #include <functional>
 #include "duckdb/common/enums/catalog_type.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -76,7 +77,8 @@ public:
 	DUCKDB_API const CatalogSearchEntry &GetDefault() const;
 	//! FIXME: this method is deprecated
 	DUCKDB_API Identifier GetDefaultSchema(const Identifier &catalog) const;
-	DUCKDB_API Identifier GetDefaultSchema(ClientContext &context, const Identifier &catalog) const;
+	//! Returns nullopt if the catalog exists but has no default schema
+	DUCKDB_API optional<Identifier> GetDefaultSchema(ClientContext &context, const Identifier &catalog) const;
 	DUCKDB_API Identifier GetDefaultCatalog(const Identifier &schema) const;
 
 	DUCKDB_API vector<Identifier> GetSchemasForCatalog(const Identifier &catalog) const;

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -167,7 +167,11 @@ void Binder::SearchSchema(CreateInfo &info) {
 		schema_path.push_back(default_entry.GetSchema());
 	} else if (schema_path.empty()) {
 		// a catalog was given but no schema: use the catalog's default schema
-		schema_path.push_back(search_path->GetDefaultSchema(context, catalog));
+		auto default_schema = search_path->GetDefaultSchema(context, catalog);
+		if (!default_schema) {
+			throw BinderException("Catalog \"%s\" has no default schema - specify a schema explicitly", catalog);
+		}
+		schema_path.push_back(*default_schema);
 	} else if (IsInvalidCatalog(catalog)) {
 		// a schema was given but no catalog: resolve the catalog that holds it
 		catalog = Identifier(search_path->GetDefaultCatalog(schema_path[0]));

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -109,8 +109,8 @@ vector<CatalogSearchEntry> Binder::GetSearchPath(Catalog &catalog, const Identif
 		view_search_path.emplace_back(catalog_name, schema_name);
 	}
 	auto default_schema = catalog.GetDefaultSchema();
-	if (schema_name.empty() && schema_name != default_schema) {
-		view_search_path.emplace_back(catalog_name, default_schema);
+	if (default_schema && schema_name.empty() && schema_name != *default_schema) {
+		view_search_path.emplace_back(catalog_name, *default_schema);
 	}
 	//! Signal that this catalog should be checked, regardless of the schema in the reference
 	view_search_path.emplace_back(catalog_name, INVALID_SCHEMA, default_schema_precedence);


### PR DESCRIPTION
This way, if an extension implements a new storage, they don't need to create a default schema. The Iceberg Catalog does no enforce default schema creation or any assumptions of default schemas. Because of this, `Attach`ing an Iceberg catalog has required some hacks around `TryLookupCatalogEntry`. If GetDefaultSchema returns `nullptr` then it is clear and obvious that a default schema should not be scanned for whatever lookup there is. 